### PR TITLE
update to kotlin 1.3.61

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To add to project in the common module add the dependency:
 sourceSets {
   commonMain {
       dependencies {
-          implementation "com.willowtreeapps:fuzzywuzzy-kotlin:0.1.1"
+          implementation "com.willowtreeapps:fuzzywuzzy-kotlin:0.9.0"
       }
    }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.moowork.node'
 archivesBaseName = 'fuzzywuzzy-kotlin'
 
 group 'com.willowtreeapps'
-version '0.1.1'
+version '0.9.0'
 final nodeVersion = '11.2.0'
 final nodeWorkingDir = project.buildDir
 final nodeModules = "$nodeWorkingDir/node_modules"

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 GROUP=com.willowtreeapps.fuzzywuzzy-kotlin
-VERSION_NAME=0.1.1
+VERSION_NAME=0.9.0
 
 POM_ARTIFACT_ID=fuzzywuzzy
 POM_DESCRIPTION=Fuzzy string matching for kotlin multiplatform

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,12 +1,11 @@
 ext.versions = [
-        kotlin          : '1.3.30',
-        kotlinCoroutines: '1.2.0',
+        kotlin          : '1.3.61',
+        kotlinCoroutines: '1.3.2',
         dokka           : '0.9.17',
         nodePlugin: '1.2.0'
 ]
 ext.deps = [
         plugins: [
-                android: 'com.android.tools.build:gradle:3.3.0',
                 kotlin : "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
                 dokka  : "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}",
                 node   : "com.moowork.gradle:gradle-node-plugin:${versions.nodePlugin}"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip


### PR DESCRIPTION
Updates:
 - kotlin 1.2.61 
 - gradle 5.6.2
 - remove unused AGP declaration
 - bump version to 0.9.0 (large bump - think it is warranted because KMP is much more stable, and we have tests in place )